### PR TITLE
Add support for new env variables that must be set for async components in babel 7 configuration

### DIFF
--- a/server/builder.js
+++ b/server/builder.js
@@ -73,10 +73,13 @@ async function processPush(push) {
 
 	// run the JS build in webpack analyze mode
 	await cmd(
-		'CALYPSO_CLIENT=true npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json',
+		'npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json',
 		{
 			useShell: true,
-			env: { NODE_ENV: 'production' },
+			env: {
+				NODE_ENV: 'production',
+				CALYPSO_CLIENT: 'true',
+			},
 		}
 	);
 

--- a/server/builder.js
+++ b/server/builder.js
@@ -73,7 +73,7 @@ async function processPush(push) {
 
 	// run the JS build in webpack analyze mode
 	await cmd(
-		'npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json',
+		'CALYPSO_CLIENT=true npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json',
 		{
 			useShell: true,
 			env: { NODE_ENV: 'production' },


### PR DESCRIPTION
When trying to measure the impact of babel 7 I realized that the configuraition changes are mismatched between the PR and icfy.

We must set `CALYPSO_CLIENT=true` so that the new `.babelrc.js` file can determine whether or not to split `asyncRequire` components to their own chunks.
See: https://github.com/Automattic/wp-calypso/pull/23026/files#diff-8363ab4678bef8ef4d374bd410e88532R5