### PR TITLE
Fix totals for areas in comments

### DIFF
--- a/server/comments.js
+++ b/server/comments.js
@@ -35,6 +35,51 @@ function groupByArea(deltas) {
 	});
 }
 
+function totalDeltasForArea(areaDelta, delta) {
+	if (!areaDelta) {
+		return {};
+	}
+
+	// Produce an array of arrays:
+	// [ [ chunks in use in first commit ] , [ chunks in use in second commit ] ]
+	// The items will be unique inside each array.
+	const chunksInUse = ['firstChunks', 'secondChunks']
+		.map(chunkType => areaDelta.reduce(
+			(acc, group) => {
+				for (chunk of group[chunkType]) {
+					acc.add(chunk);
+				}
+				return acc;
+			},
+			new Set()
+		))
+		.map(set => [...set]);
+
+	// Produce an array of size objects, representing the sum of all the chunks for each commit:
+	// [ { stat_size: 0, parsed_size: 0, gzip_size: 0 }, { stat_size: 0, parsed_size: 0, gzip_size: 0 } ]
+	// The first object is for the first commit, and the second object for the second commit.
+	const chunkSizes = ['firstSizes', 'secondSizes']
+		.map((property, index) => chunksInUse[index].reduce(
+			(acc, chunkName) => {
+				const chunk = delta.chunks.find(chunk => chunk.name === chunkName) || {};
+				for (size in chunk[property]) {
+					acc[size] = chunk[property][size] + (acc[size] || 0);
+				}
+				return acc;
+			},
+			{}
+		));
+
+	// Produce a single object with the delta between first and second commit:
+	// { stat_size: 0, parsed_size: 0, gzip_size: 0 }
+	let deltaSizes = {};
+	for (sizeType in chunkSizes[0]) {
+		deltaSizes[sizeType] = chunkSizes[1][sizeType] - chunkSizes[0][sizeType];
+	}
+
+	return deltaSizes;
+}
+
 const AREAS = [
 	{
 		id: 'runtime',
@@ -90,8 +135,11 @@ function watermarkString(watermark) {
 	return `icfy-watermark: ${watermark}`;
 }
 
-async function statsMessage(push) {
-	const delta = await db.getPushDelta(push.ancestor, push.sha, { extractManifestGroup: true });
+async function getDelta(push) {
+	return await db.getPushDelta(push.ancestor, push.sha, { extractManifestGroup: true });
+}
+
+function statsMessage(delta) {
 	const byArea = groupByArea(delta.groups);
 
 	const message = [];
@@ -112,7 +160,7 @@ async function statsMessage(push) {
 				continue;
 			}
 
-			const bytesDelta = _.reduce(areaDelta, (sum, delta) => sum + delta.deltaSizes.gzip_size, 0);
+			const bytesDelta = totalDeltasForArea(areaDelta, delta).gzip_size || 0;
 			const changedBytes = Math.abs(bytesDelta);
 			const suffix = bytesDelta < 0 ? 'removed 📉' : 'added 📈';
 
@@ -187,7 +235,7 @@ module.exports = async function commentOnGithub(sha) {
 
 	const [firstComment, ...otherComments] = await getOurPRCommentIDs(REPO, prNumber);
 
-	const message = await statsMessage(push);
+	const message = statsMessage(await getDelta(push));
 
 	if (!firstComment) {
 		log('Posting first comment on PR', prNumber);

--- a/server/comments.js
+++ b/server/comments.js
@@ -46,7 +46,7 @@ function totalDeltasForArea(areaDelta, delta) {
 	const chunksInUse = ['firstChunks', 'secondChunks']
 		.map(chunkType => areaDelta.reduce(
 			(acc, group) => {
-				for (chunk of group[chunkType]) {
+				for (const chunk of group[chunkType]) {
 					acc.add(chunk);
 				}
 				return acc;
@@ -62,8 +62,8 @@ function totalDeltasForArea(areaDelta, delta) {
 		.map((property, index) => chunksInUse[index].reduce(
 			(acc, chunkName) => {
 				const chunk = delta.chunks.find(chunk => chunk.name === chunkName) || {};
-				for (size in chunk[property]) {
-					acc[size] = chunk[property][size] + (acc[size] || 0);
+				for (const sizeType in chunk[property]) {
+					acc[sizeType] = chunk[property][sizeType] + (acc[sizeType] || 0);
 				}
 				return acc;
 			},
@@ -73,7 +73,7 @@ function totalDeltasForArea(areaDelta, delta) {
 	// Produce a single object with the delta between first and second commit:
 	// { stat_size: 0, parsed_size: 0, gzip_size: 0 }
 	let deltaSizes = {};
-	for (sizeType in chunkSizes[0]) {
+	for (const sizeType in chunkSizes[0]) {
 		deltaSizes[sizeType] = chunkSizes[1][sizeType] - chunkSizes[0][sizeType];
 	}
 

--- a/server/comments.js
+++ b/server/comments.js
@@ -3,6 +3,7 @@ const { log, getPRNumber } = require('./utils');
 const db = require('./db');
 const gh = require('./github');
 const printDeltaTable = require('./delta-table');
+const { sumSizesOf, ZERO_SIZE } = require('./delta');
 
 const REPO = 'Automattic/wp-calypso';
 const WATERMARK = 'c52822';
@@ -37,7 +38,7 @@ function groupByArea(deltas) {
 
 function totalDeltasForArea(areaDelta, delta) {
 	if (!areaDelta) {
-		return {};
+		return {...ZERO_SIZE};
 	}
 
 	// Produce an array of arrays:
@@ -62,12 +63,10 @@ function totalDeltasForArea(areaDelta, delta) {
 		.map((property, index) => chunksInUse[index].reduce(
 			(acc, chunkName) => {
 				const chunk = delta.chunks.find(chunk => chunk.name === chunkName) || {};
-				for (const sizeType in chunk[property]) {
-					acc[sizeType] = chunk[property][sizeType] + (acc[sizeType] || 0);
-				}
+				acc = sumSizesOf(acc, chunk[property]);
 				return acc;
 			},
-			{}
+			{...ZERO_SIZE}
 		));
 
 	// Produce a single object with the delta between first and second commit:

--- a/server/delta.js
+++ b/server/delta.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
 const sizes = ['stat_size', 'parsed_size', 'gzip_size'];
+const ZERO_SIZE = sizes.reduce((acc, size) => ({...acc, [size]: 0}), {});
 
 function sizesOf(stat) {
 	return stat ? _.pick(stat, sizes) : null;
@@ -266,3 +267,5 @@ function deltaFromStatsAndGroups(firstStats, firstGroups, secondStats, secondGro
 
 exports.deltaFromStats = deltaFromStats;
 exports.deltaFromStatsAndGroups = deltaFromStatsAndGroups;
+exports.sumSizesOf = sumSizesOf;
+exports.ZERO_SIZE = ZERO_SIZE;

--- a/server/delta.js
+++ b/server/delta.js
@@ -225,6 +225,8 @@ function deltaFromStatsAndGroups(firstStats, firstGroups, secondStats, secondGro
 		const secondSizes = sizesOfGroup(secondGroup, secondStats);
 		const deltaSizes = deltaSizesOf(firstSizes, secondSizes);
 		const deltaPercents = deltaPercentsOf(firstSizes, deltaSizes);
+		const firstChunks = (firstGroup || {}).chunks || [];
+		const secondChunks = (secondGroup || {}).chunks || [];
 
 		if (isDeltaEligible(deltaSizes)) {
 			deltas.push({
@@ -233,6 +235,8 @@ function deltaFromStatsAndGroups(firstStats, firstGroups, secondStats, secondGro
 				secondSizes,
 				deltaSizes,
 				deltaPercents,
+				firstChunks,
+				secondChunks,
 			});
 		}
 	}
@@ -243,12 +247,16 @@ function deltaFromStatsAndGroups(firstStats, firstGroups, secondStats, secondGro
 			const firstSizes = null;
 			const secondSizes = sizesOfGroup(secondGroup, secondStats);
 			const deltaSizes = deltaSizesOf(firstSizes, secondSizes);
+			const firstChunks = [];
+			const secondChunks = secondGroup.chunks || [];
 
 			deltas.push({
 				name,
 				firstSizes,
 				secondSizes,
 				deltaSizes,
+				firstChunks,
+				secondChunks,
 			});
 		}
 	}


### PR DESCRIPTION
GitHub comments by ICFY currently have an issue with calculating totals for a particular "area". For example, for sections:

```
**Sections** (~119368 bytes removed 📉 [gzipped])

name                   parsed_size            gzip_size
signup                   -159335 B  (-31.0%)   -37498 B  (-29.4%)
checkout                 -152990 B   (-9.3%)   -35377 B   (-8.7%)
gutenberg-editor         -149228 B  (-26.6%)   -35530 B  (-23.0%)
reader                     -2907 B   (-0.5%)     -508 B   (-0.3%)
plans                      -2625 B   (-0.3%)     -399 B   (-0.2%)
jetpack-connect            -2436 B   (-0.3%)     -471 B   (-0.3%)
jetpack-cloud-pricing      -2436 B   (-0.6%)     -471 B   (-0.4%)
hosting                    -2436 B   (-0.8%)     -471 B   (-0.6%)
woocommerce                -1107 B   (-0.0%)     -307 B   (-0.1%)
posts-custom                -677 B   (-0.2%)     -151 B   (-0.1%)
posts                       -677 B   (-0.2%)     -151 B   (-0.1%)
settings                    -540 B   (-0.1%)     -590 B   (-0.4%)
privacy                     -410 B   (-0.1%)    -1066 B   (-1.3%)
settings-security           -398 B   (-0.1%)      -34 B   (-0.0%)
settings-writing            -391 B   (-0.1%)      -64 B   (-0.0%)
plugins                     -380 B   (-0.1%)      -38 B   (-0.0%)
purchases                   -339 B   (-0.0%)     +113 B   (+0.0%)
site-blocks                 -314 B   (-0.1%)    -1037 B   (-1.2%)
account                     -303 B   (-0.1%)    -1038 B   (-1.0%)
media                       -273 B   (-0.1%)     +299 B   (+0.2%)
wp-super-cache              -247 B   (-0.1%)      -30 B   (-0.0%)
settings-performance        -247 B   (-0.1%)      -30 B   (-0.0%)
settings-discussion         -247 B   (-0.1%)      -30 B   (-0.0%)
marketing                   -247 B   (-0.0%)      -30 B   (-0.0%)
earn                        -247 B   (-0.1%)      -25 B   (-0.0%)
site-purchases              -234 B   (-0.0%)     +608 B   (+0.3%)
home                        -203 B   (-0.0%)     -347 B   (-0.3%)
stats                       -195 B   (-0.0%)      -49 B   (-0.0%)
google-my-business          -169 B   (-0.1%)      -24 B   (-0.0%)
security                    -163 B   (-0.0%)    -1031 B   (-0.8%)
notification-settings       -163 B   (-0.0%)    -1031 B   (-1.1%)
me                          -163 B   (-0.1%)    -1031 B   (-1.4%)
happychat                   -163 B   (-0.1%)    -1031 B   (-1.2%)
account-close               -163 B   (-0.0%)    -1031 B   (-1.1%)
zoninator                   -151 B   (-0.1%)      -10 B   (-0.0%)
people                      -142 B   (-0.0%)      -70 B   (-0.1%)
import                      -142 B   (-0.1%)     -119 B   (-0.2%)
domains                     -135 B   (-0.0%)     +145 B   (+0.1%)
pages                       +101 B   (+0.0%)     +142 B   (+0.2%)
devdocs                      -95 B   (-0.0%)       -7 B   (-0.0%)
help                         -52 B   (-0.0%)       -1 B   (-0.0%)
email                        +42 B   (+0.0%)     +453 B   (+0.5%)
```

We see that the total is being calculated simply by adding up all the individual diffs for each group. This is incorrect, since groups can share chunks, and if a shared chunk changes size, it will be counted multiple times with this approach.

This PR instead takes shared chunks into account, by adding up all the chunks in use across an entire area for the "before" and "after" commits, and subtracting those sums instead (note: the values are slightly different because the above is from a PR and the below is from its merge):

```
**Sections** (~54533 bytes removed 📉 [gzipped])

name                   parsed_size            gzip_size
signup                   -159335 B  (-31.0%)   -37497 B  (-29.3%)
checkout                 -152990 B   (-9.3%)   -35377 B   (-8.7%)
gutenberg-editor         -149228 B  (-26.6%)   -35525 B  (-23.0%)
reader                     -2907 B   (-0.5%)     -508 B   (-0.3%)
plans                      -2625 B   (-0.3%)     -399 B   (-0.2%)
jetpack-connect            -2436 B   (-0.3%)     -471 B   (-0.3%)
jetpack-cloud-pricing      -2436 B   (-0.6%)     -471 B   (-0.4%)
hosting                    -2436 B   (-0.8%)     -471 B   (-0.6%)
woocommerce                -1107 B   (-0.0%)     -305 B   (-0.1%)
posts-custom                -677 B   (-0.2%)     -151 B   (-0.1%)
posts                       -677 B   (-0.2%)     -151 B   (-0.1%)
settings                    -556 B   (-0.1%)     -606 B   (-0.4%)
privacy                     -410 B   (-0.1%)    -1066 B   (-1.3%)
settings-security           -398 B   (-0.1%)      -34 B   (-0.0%)
settings-writing            -391 B   (-0.1%)      -64 B   (-0.0%)
plugins                     -380 B   (-0.1%)      -38 B   (-0.0%)
purchases                   -339 B   (-0.0%)     +113 B   (+0.0%)
site-blocks                 -314 B   (-0.1%)    -1037 B   (-1.2%)
account                     -303 B   (-0.1%)    -1038 B   (-1.0%)
media                       -273 B   (-0.1%)     +299 B   (+0.2%)
wp-super-cache              -247 B   (-0.1%)      -30 B   (-0.0%)
settings-performance        -247 B   (-0.1%)     +106 B   (+0.1%)
settings-discussion         -247 B   (-0.1%)      -30 B   (-0.0%)
earn                        -247 B   (-0.1%)      -25 B   (-0.0%)
marketing                   -235 B   (-0.0%)     +362 B   (+0.3%)
site-purchases              -234 B   (-0.0%)     +608 B   (+0.3%)
people                      -219 B   (-0.1%)     -842 B   (-0.9%)
home                        -203 B   (-0.0%)     -347 B   (-0.3%)
stats                       -195 B   (-0.0%)      -49 B   (-0.0%)
security                    -163 B   (-0.0%)    -1031 B   (-0.8%)
notification-settings       -163 B   (-0.0%)    -1031 B   (-1.1%)
me                          -163 B   (-0.1%)    -1031 B   (-1.4%)
happychat                   -163 B   (-0.1%)    -1031 B   (-1.2%)
account-close               -163 B   (-0.0%)    -1031 B   (-1.1%)
zoninator                   -151 B   (-0.1%)      -10 B   (-0.0%)
import                      -142 B   (-0.1%)      -93 B   (-0.1%)
domains                     -135 B   (-0.0%)     +145 B   (+0.1%)
pages                       +101 B   (+0.0%)     +142 B   (+0.2%)
devdocs                      -95 B   (-0.0%)       -7 B   (-0.0%)
google-my-business           -80 B   (-0.0%)     +990 B   (+1.1%)
help                         -52 B   (-0.0%)       -1 B   (-0.0%)
email                        +42 B   (+0.0%)     +453 B   (+0.5%)
```

This should reduce confusion, and more accurately convey the impact of a PR.